### PR TITLE
Do not import parsl before dependencies are set up.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 from setuptools import setup, find_packages
-from libsubmit.version import VERSION
+
+with open('parsl/version.py') as f:
+    exec(f.read())
 
 install_requires = [
     'ipyparallel',

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open('parsl/version.py') as f:
+with open('libsubmit/version.py') as f:
     exec(f.read())
 
 install_requires = [


### PR DESCRIPTION
Needed for Parsl/parsl#139.