### PR TITLE
Make Popen process its own group leader

### DIFF
--- a/libsubmit/channels/local/local.py
+++ b/libsubmit/channels/local/local.py
@@ -123,7 +123,8 @@ class LocalChannel(Channel):
                 stderr=subprocess.PIPE,
                 cwd=self.userhome,
                 env=current_env,
-                shell=True
+                shell=True,
+                preexec_fn=os.setpgrp
             )
             pid = proc.pid
 


### PR DESCRIPTION
Otherwise, when running in Jupyter on Mac, the ipykernel will have the
same group ID as the engines, and will be killed when the Popen process's group ID is
killed. Fixes Parsl/parsl#212.