### PR TITLE
Make walltime copy and pastable

### DIFF
--- a/libsubmit/providers/cluster_provider.py
+++ b/libsubmit/providers/cluster_provider.py
@@ -3,7 +3,6 @@ import os
 from string import Template
 
 import libsubmit.error as ep_error
-from libsubmit.utils import wtime_to_minutes
 from libsubmit.providers.provider_base import ExecutionProvider
 
 logger = logging.getLogger(__name__)
@@ -74,7 +73,7 @@ class ClusterProvider(ExecutionProvider):
         self.parallelism = parallelism
         self.provisioned_blocks = 0
         self.launcher = launcher
-        self.walltime = wtime_to_minutes(walltime)
+        self.walltime = walltime
         self.cmd_timeout = cmd_timeout
         if not callable(self.launcher):
             raise(ep_error.BadLauncher(self.launcher,

--- a/libsubmit/providers/cobalt/cobalt.py
+++ b/libsubmit/providers/cobalt/cobalt.py
@@ -7,7 +7,7 @@ from libsubmit.channels import LocalChannel
 from libsubmit.launchers import AprunLauncher
 from libsubmit.providers.cobalt.template import template_string
 from libsubmit.providers.cluster_provider import ClusterProvider
-from libsubmit.utils import RepresentationMixin
+from libsubmit.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +190,7 @@ class CobaltProvider(ClusterProvider, RepresentationMixin):
         channel_script_path = self.channel.push_file(script_path, self.channel.script_dir)
 
         command = 'qsub -n {0} {1} -t {2} {3} {4}'.format(
-            self.nodes_per_block, queue_opt, self.walltime, account_opt, channel_script_path)
+            self.nodes_per_block, queue_opt, wtime_to_minutes(self.walltime), account_opt, channel_script_path)
         logger.debug("Executing {}".format(command))
 
         retcode, stdout, stderr = super().execute_wait(command)

--- a/libsubmit/providers/grid_engine/grid_engine.py
+++ b/libsubmit/providers/grid_engine/grid_engine.py
@@ -6,7 +6,7 @@ from libsubmit.channels import LocalChannel
 from libsubmit.providers.cluster_provider import ClusterProvider
 from libsubmit.providers.grid_engine.template import template_string
 from libsubmit.launchers import SingleNodeLauncher
-from libsubmit.utils import RepresentationMixin
+from libsubmit.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +104,7 @@ class GridEngineProvider(ClusterProvider, RepresentationMixin):
         job_config = {}
         job_config["submit_script_dir"] = self.channel.script_dir
         job_config["nodes"] = self.nodes_per_block
-        job_config["walltime"] = self.walltime
+        job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["overrides"] = self.overrides
         job_config["user_script"] = command
 

--- a/libsubmit/providers/slurm/slurm.py
+++ b/libsubmit/providers/slurm/slurm.py
@@ -6,7 +6,7 @@ from libsubmit.channels import LocalChannel
 from libsubmit.launchers import SingleNodeLauncher
 from libsubmit.providers.cluster_provider import ClusterProvider
 from libsubmit.providers.slurm.template import template_string
-from libsubmit.utils import RepresentationMixin
+from libsubmit.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +163,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_config = {}
         job_config["submit_script_dir"] = self.channel.script_dir
         job_config["nodes"] = self.nodes_per_block
-        job_config["walltime"] = self.walltime
+        job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["overrides"] = self.overrides
         job_config["partition"] = self.partition
         job_config["user_script"] = command

--- a/libsubmit/providers/torque/torque.py
+++ b/libsubmit/providers/torque/torque.py
@@ -5,7 +5,7 @@ import time
 from libsubmit.launchers import AprunLauncher
 from libsubmit.providers.torque.template import template_string
 from libsubmit.providers.cluster_provider import ClusterProvider
-from libsubmit.utils import RepresentationMixin
+from libsubmit.utils import RepresentationMixin, wtime_to_minutes
 
 logger = logging.getLogger(__name__)
 
@@ -187,7 +187,7 @@ class TorqueProvider(ClusterProvider, RepresentationMixin):
         job_config["task_blocks"] = self.nodes_per_block * self.tasks_per_node
         job_config["nodes_per_block"] = self.nodes_per_block
         job_config["tasks_per_node"] = self.tasks_per_node
-        job_config["walltime"] = self.walltime
+        job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["overrides"] = self.overrides
         job_config["user_script"] = command
 


### PR DESCRIPTION
This ensures that the walltime string is saved in the provider
initializer, such that when the configuration is printed, it can be
copied. Fixes Parsl/parsl#350.