### PR TITLE
Make Launcher inherit from RepresentationMixin

### DIFF
--- a/libsubmit/launchers/launchers.py
+++ b/libsubmit/launchers/launchers.py
@@ -1,7 +1,9 @@
 from abc import ABCMeta, abstractmethod
 
+from libsubmit.utils import RepresentationMixin
 
-class Launcher(metaclass=ABCMeta):
+
+class Launcher(RepresentationMixin, metaclass=ABCMeta):
     """ Launcher base class to enforce launcher interface
     """
     @abstractmethod


### PR DESCRIPTION
This allows configs to be copy-and-pasteable. Fixes Parsl/parsl#428.