### PR TITLE
GNU Parrallel & mpiexec launchers

### DIFF
--- a/libsubmit/launchers/__init__.py
+++ b/libsubmit/launchers/__init__.py
@@ -1,8 +1,13 @@
-from libsubmit.launchers.launchers import SimpleLauncher, SingleNodeLauncher, SrunLauncher, AprunLauncher, SrunMPILauncher, AprunLauncher
+from libsubmit.launchers.launchers import SimpleLauncher, SingleNodeLauncher, \
+    SrunLauncher, AprunLauncher, SrunMPILauncher, AprunLauncher, \
+    GnuParallelLauncher, MpiExecLauncher
 
 __all__ = ['SimpleLauncher',
            'SingleNodeLauncher',
            'SrunLauncher',
            'AprunLauncher',
            'SrunMPILauncher',
-           'AprunLauncher']
+           'AprunLauncher',
+           'GnuParallelLauncher',
+           'MpiExecLauncher']
+

--- a/libsubmit/launchers/launchers.py
+++ b/libsubmit/launchers/launchers.py
@@ -147,7 +147,7 @@ echo "Found cores : $CORES"
 WORKERCOUNT={3}
 
 # Deduplicate the nodefile
-SSHLOGINFILE="$JOBNAME.nodes"
+HOSTFILE="$JOBNAME.nodes"
 sort -u $PBS_NODEFILE > $HOSTFILE
 
 cat << MPIEXEC_EOF > cmd_$JOBNAME.sh


### PR DESCRIPTION
This PR adds two new launchers.

The GnuParallelLauncher uses GNU Parallel to launch `tasks_per_node` workers on each node allocated by a provider. Current implementation assumes a PBS provider.

The MpiExecLauncher uses `mpiexec` to launch `tasks_per_node` workers on each node allocated by a provider. Current implementation assumes a PBS provider.