### PR TITLE
Pass `ntasks-per-node` in slurm script

### DIFF
--- a/libsubmit/providers/slurm/slurm.py
+++ b/libsubmit/providers/slurm/slurm.py
@@ -163,6 +163,7 @@ class SlurmProvider(ClusterProvider, RepresentationMixin):
         job_config = {}
         job_config["submit_script_dir"] = self.channel.script_dir
         job_config["nodes"] = self.nodes_per_block
+        job_config["tasks_per_node"] = self.tasks_per_node
         job_config["walltime"] = wtime_to_minutes(self.walltime)
         job_config["overrides"] = self.overrides
         job_config["partition"] = self.partition

--- a/libsubmit/providers/slurm/template.py
+++ b/libsubmit/providers/slurm/template.py
@@ -6,6 +6,7 @@ template_string = '''#!/bin/bash
 #SBATCH --nodes=${nodes}
 #SBATCH --partition=${partition}
 #SBATCH --time=${walltime}
+#SBATCH --ntasks-per-node=${tasks_per_node}
 
 $overrides
 


### PR DESCRIPTION
This fix was suggested by @reidmcy. Without specifying
`ntasks-per-node`, all engines are started on the same core when using `SingleNodeLauncher`.
Fixes Parsl/parsl#454.