### PR TITLE
Explicitly disable processor binding in all cases for the MpiExecLauncher.

### DIFF
--- a/libsubmit/launchers/launchers.py
+++ b/libsubmit/launchers/launchers.py
@@ -154,7 +154,7 @@ WORKERCOUNT={3}
 
 # Deduplicate the nodefile
 HOSTFILE="$JOBNAME.nodes"
-if [ -z "$HOSTFILE" ]; then
+if [ -z "$PBS_NODEFILE" ]; then
     echo "localhost" > $HOSTFILE
 else
     sort -u $PBS_NODEFILE > $HOSTFILE

--- a/libsubmit/launchers/launchers.py
+++ b/libsubmit/launchers/launchers.py
@@ -154,7 +154,7 @@ WORKERCOUNT={3}
 
 # Deduplicate the nodefile
 HOSTFILE="$JOBNAME.nodes"
-if [ -z "$PBS_NODEFILE" ]; then
+if [ -z "$HOSTFILE" ]; then
     echo "localhost" > $HOSTFILE
 else
     sort -u $PBS_NODEFILE > $HOSTFILE


### PR DESCRIPTION
mpiexec has two different processor binding strategies, depending on the number of processes launched. For `np >= 2` the default strategy is `none`, which allows all processes launched to utilize all cores. For `np == 1` the default strategy is `core`, which binds the process to a single core.

This change explicitly sets the strategy to `none` so that a `Executor` specification set with `tasks_per_node = 1` will utilize all cores on a node, instead of just one.