### PR TITLE
Python2.7 compatibility

### DIFF
--- a/libsubmit/channels/channel_base.py
+++ b/libsubmit/channels/channel_base.py
@@ -1,7 +1,8 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+import six
 
-
-class Channel(metaclass=ABCMeta):
+@six.add_metaclass(ABCMeta)
+class Channel():
     """ Define the interface to all channels. Channels are usually called via the execute_wait function.
     For channels that execute remotely, a push_file function allows you to copy over files.
 

--- a/libsubmit/launchers/launchers.py
+++ b/libsubmit/launchers/launchers.py
@@ -1,9 +1,11 @@
 from abc import ABCMeta, abstractmethod
+import six
 
 from libsubmit.utils import RepresentationMixin
 
 
-class Launcher(RepresentationMixin, metaclass=ABCMeta):
+@six.add_metaclass(ABCMeta)
+class Launcher(RepresentationMixin):
     """ Launcher base class to enforce launcher interface
     """
     @abstractmethod

--- a/libsubmit/providers/aws/aws.py
+++ b/libsubmit/providers/aws/aws.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 import json
 import logging
 import os
@@ -593,8 +594,8 @@ class AWSProvider(ExecutionProvider, RepresentationMixin):
         wrapped_cmd = self.launcher(command,
                                     self.tasks_per_node,
                                     self.nodes_per_block)
-        [instance, *rest] = self.spin_up_instance(command=wrapped_cmd, job_name=job_name)
-
+        instance_data = self.spin_up_instance(command=wrapped_cmd, job_name=job_name)
+        instance, rest = instance_data[0], instance_data[1:]
         if not instance:
             logger.error("Failed to submit request to EC2")
             return None

--- a/libsubmit/providers/azure/azure.py
+++ b/libsubmit/providers/azure/azure.py
@@ -131,7 +131,8 @@ class AzureProvider(ExecutionProvider, RepresentationMixin):
         """
 
         job_name = "parsl.auto.{0}".format(time.time())
-        [instance, *rest] = self.deployer.deploy(command=command, job_name=job_name, blocksize=1)
+        instance_data = self.deployer.deploy(command=command, job_name=job_name, blocksize=1)
+        instance, rest = instance_data[0], instance_data[1:]
 
         if not instance:
             logger.error("Failed to submit request to Azure")

--- a/libsubmit/providers/kubernetes/kube.py
+++ b/libsubmit/providers/kubernetes/kube.py
@@ -7,6 +7,12 @@ logger = logging.getLogger(__name__)
 from libsubmit.error import *
 from libsubmit.providers.provider_base import ExecutionProvider
 
+# Compatibility with python2.7, FileNotFoundError is not defined
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 try:
     from kubernetes import client, config
     config.load_kube_config()

--- a/libsubmit/providers/provider_base.py
+++ b/libsubmit/providers/provider_base.py
@@ -1,7 +1,9 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
+import six
 
 
-class ExecutionProvider(metaclass=ABCMeta):
+@six.add_metaclass(ABCMeta)
+class ExecutionProvider():
     """ Define the strict interface for all Execution Provider
 
     .. code:: python

--- a/libsubmit/providers/slurm/slurm.py
+++ b/libsubmit/providers/slurm/slurm.py
@@ -1,3 +1,4 @@
+# -*- coding: future_fstrings -*-
 import logging
 import os
 import time

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ google-api-python-client
 google-auth
 nbsphinx
 kubernetes>=6.0.0
+six
+configparser
+future-fstrings

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         # Licence, must match with licence above
         'License :: OSI Approved :: Apache Software License',
         # Python versions supported
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,17 @@ with open('libsubmit/version.py') as f:
     exec(f.read())
 
 install_requires = [
-    'paramiko'
+    'paramiko',
+    'six',
+    'configparser',
+    'future-fstrings',
     ]
 
 tests_require = [
     'paramiko',
+    'six',
+    'configparser',
+    'future-fstrings',
     'mock>=1.0.0',
     'nose',
     'pytest'


### PR DESCRIPTION
While python 3 is becoming standard practice, some legacy applications still require python 2.7. The following minor changes allow compatibility with both python versions. We would like to see support for python 2.7 to avoid the need to create a separate fork of the project.