### PR TITLE
Windows compatibility

### DIFF
--- a/libsubmit/channels/local/local.py
+++ b/libsubmit/channels/local/local.py
@@ -145,7 +145,7 @@ class LocalChannel(Channel, RepresentationMixin):
             - FileCopyException : If file copy failed.
         '''
 
-        local_dest = dest_dir + '/' + os.path.basename(source)
+        local_dest = os.path.join(dest_dir, os.path.basename(source))
 
         # Only attempt to copy if the target dir and source dir are different
         if os.path.dirname(source) != dest_dir:

--- a/libsubmit/channels/ssh/ssh.py
+++ b/libsubmit/channels/ssh/ssh.py
@@ -202,7 +202,7 @@ class SSHChannel(RepresentationMixin):
             - FileCopyException : FileCopy failed.
         '''
 
-        local_dest = local_dir + '/' + os.path.basename(remote_source)
+        local_dest = os.path.join(local_dir, os.path.basename(remote_source))
 
         try:
             os.makedirs(local_dir)

--- a/libsubmit/providers/cluster_provider.py
+++ b/libsubmit/providers/cluster_provider.py
@@ -113,8 +113,9 @@ class ClusterProvider(ExecutionProvider):
 
         try:
             submit_script = Template(template).substitute(jobname=job_name, **configs)
+            submit_script = submit_script.replace("\r\n", "\n")
             # submit_script = Template(template).safe_substitute(jobname=job_name, **configs)
-            with open(script_filename, 'w') as f:
+            with open(script_filename, 'wb') as f:
                 f.write(submit_script)
 
         except KeyError as e:


### PR DESCRIPTION
This pull request includes two small changes to increase compatibility with Windows.

1. The _write_submit_script routine in cluster_provider produced a script with os dependent line endings. In order to create a file with posix line endings, the file writing mode is changed to binary and Windows line endings in the submit_script string are replaced with posix line endings.

2. Local file paths in SSHChannel and LocalChannel classes are constructed using os.path.
